### PR TITLE
Add apostrophes in regex for email

### DIFF
--- a/validators/validators.go
+++ b/validators/validators.go
@@ -14,8 +14,9 @@ const (
 	 * https://github.com/PlanitarInc/walk-inside-app/blob/master/app/lib/utils.js
 	 */
 	/* XXX This should be sufficient for 99% of the cases */
-	idPattern         = "([0-9a-zA-Z][-0-9a-zA-Z.+_']*)?[0-9a-zA-Z_]"
-	domainnamePattern = idPattern + "\\.[a-zA-Z]{2,10}"
+	idPattern         = "([0-9a-zA-Z!#$%&'*+\\/=\\?^_`{|}~][-0-9a-zA-Z.!#$%&'*+-\\/=\\?^_`{|}~]*)?[0-9a-zA-Z!#$%&'*+\\/=\\?^_`{|}~]"
+	domainName        = "([0-9a-zA-Z][-0-9a-zA-Z.+_]*)?[0-9a-zA-Z_]"
+	domainnamePattern = domainName + "\\.[a-zA-Z]{2,10}"
 	emailPattern      = "^" + idPattern + "@" + domainnamePattern + "$"
 )
 

--- a/validators/validators.go
+++ b/validators/validators.go
@@ -14,7 +14,7 @@ const (
 	 * https://github.com/PlanitarInc/walk-inside-app/blob/master/app/lib/utils.js
 	 */
 	/* XXX This should be sufficient for 99% of the cases */
-	idPattern         = "([0-9a-zA-Z][-0-9a-zA-Z.+_]*)?[0-9a-zA-Z]"
+	idPattern         = "([0-9a-zA-Z][-0-9a-zA-Z.+_']*)?[0-9a-zA-Z_]"
 	domainnamePattern = idPattern + "\\.[a-zA-Z]{2,10}"
 	emailPattern      = "^" + idPattern + "@" + domainnamePattern + "$"
 )

--- a/validators/validators.go
+++ b/validators/validators.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/PlanitarInc/validate"
@@ -14,8 +15,9 @@ const (
 	 * https://github.com/PlanitarInc/walk-inside-app/blob/master/app/lib/utils.js
 	 */
 	/* XXX This should be sufficient for 99% of the cases */
-	idPattern         = "([0-9a-zA-Z!#$%&'*+\\/=\\?^_`{|}~][-0-9a-zA-Z.!#$%&'*+-\\/=\\?^_`{|}~]*)?[0-9a-zA-Z!#$%&'*+\\/=\\?^_`{|}~]"
-	domainName        = "([0-9a-zA-Z][-0-9a-zA-Z.+_]*)?[0-9a-zA-Z_]"
+	printable         = ".!#$%&'*+-\\/=\\?^_`{|}~"
+	idPattern         = "[0-9a-zA-Z" + printable + "][0-9a-zA-Z" + printable + "]*"
+	domainName        = "([0-9a-zA-Z][-0-9a-zA-Z.+_]*)?[0-9a-zA-Z]"
 	domainnamePattern = domainName + "\\.[a-zA-Z]{2,10}"
 	emailPattern      = "^" + idPattern + "@" + domainnamePattern + "$"
 )
@@ -169,6 +171,12 @@ func REMatch(pattern string, mismatchError ...interface{}) validate.ValidatorFn 
 		case []byte:
 			match = re.Match(src.([]byte))
 		case string:
+			if fmt.Sprintf("%v", mismatchErr) == "invalid email" {
+				if len(v) < 1 || v[:1] == "." || strings.Contains(v, "..") || strings.Contains(v, ".@") {
+					return mismatchErr
+				}
+			}
+			
 			match = re.MatchString(src.(string))
 		case []string:
 			arr := src.([]string)

--- a/validators/validators_test.go
+++ b/validators/validators_test.go
@@ -179,6 +179,9 @@ func TestEmailValidator(t *testing.T) {
 	Ω(v("d@p.aa")).Should(BeNil())
 	Ω(v("dmitri@planitar.com")).Should(BeNil())
 	Ω(v("D.m.I.t.R.i@p.L.a.N.i.T.a.R.cOm")).Should(BeNil())
+	Ω(v("angel's@yahoo.com")).Should(BeNil())
+	Ω(v("alyson.o'laughlin@wsdevelopment.com")).Should(BeNil())
+	Ω(v("happily_@planitar.com")).Should(BeNil())
 
 	Ω(v("-bad.@addr.com")).Should(Equal("invalid email"))
 	Ω(v("bad-@addr.com")).Should(Equal("invalid email"))

--- a/validators/validators_test.go
+++ b/validators/validators_test.go
@@ -85,7 +85,6 @@ func TestStrLimitValidator(t *testing.T) {
 	arr = []string{"a"}
 	Ω(StrLimit(1, 1)(arr)).Should(BeNil())
 	arr = []string{"", "asd", "bsd", "qs", ""}
-	errs = map[int]string{0: minErr(1), 1: maxErr(2), 2: maxErr(2), 4: minErr(1)}
 	e := StrLimit(1, 2)(arr)
 	Ω(e).Should(HaveKeyWithValue(0, minErr(1)))
 	Ω(e).Should(HaveKeyWithValue(1, maxErr(2)))
@@ -182,11 +181,13 @@ func TestEmailValidator(t *testing.T) {
 	Ω(v("angel's@yahoo.com")).Should(BeNil())
 	Ω(v("alyson.o'laughlin@wsdevelopment.com")).Should(BeNil())
 	Ω(v("happily_@planitar.com")).Should(BeNil())
+	Ω(v("happily-@addr.com")).Should(BeNil())
+	Ω(v("-happily@addr.com")).Should(BeNil())
 
 	Ω(v("-bad.@addr.com")).Should(Equal("invalid email"))
-	Ω(v("bad-@addr.com")).Should(Equal("invalid email"))
 	Ω(v(".bad.@addr.com")).Should(Equal("invalid email"))
 	Ω(v("bad.@addr.com")).Should(Equal("invalid email"))
+	Ω(v("bad..mail@addr.com")).Should(Equal("invalid email"))
 	Ω(v("@bad.com")).Should(Equal("invalid email"))
 	Ω(v("a@bad.")).Should(Equal("invalid email"))
 	Ω(v("a@.bad.com")).Should(Equal("invalid email"))


### PR DESCRIPTION
This PR adds apostrophes and printable characters into the validation in the email ID.
